### PR TITLE
Crossbuild for multiple environments, update installation instructions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,7 @@ jobs:
     steps:
       - checkout
       - run: gpg --import test/testing-key.pgp
-      - run: make test build
-      - run:
-          name: Download github-release tool
-          command: |
-            curl -sL 'https://github.com/aktau/github-release/releases/download/v0.6.2/linux-amd64-github-release.tar.bz2' | \
-              tar xjf - --strip-components 3 -C /go/bin
-      - run: github-release upload --user carlpett --repo terraform-provider-sops --tag $CIRCLE_TAG --name terraform-provider-sops_$CIRCLE_TAG-linux-amd64 --file terraform-provider-sops
+      - run: make test crossbuild release
       - run:
           name: Trigger Docker Hub automated build
           command: |
@@ -31,7 +25,7 @@ jobs:
               --data "{\"source_type\": \"Tag\", \"source_name\": \"$CIRCLE_TAG\"}" \
               https://registry.hub.docker.com/u/carlpett/terraform-provider-sops/trigger/$DOCKER_HUB_TRIGGER_TOKEN/
       - store_artifacts:
-          path: terraform-provider-sops
+          path: binaries
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin/
+binaries/
+releases/
+terraform-provider-sops

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,8 @@
-version = $(shell git describe --tags --match='v*' | sed 's/^v//')
+VERSION = $(shell git describe --tags --match='v*' | sed 's/^v//')
+
+CROSSBUILD_OS   = linux windows darwin
+CROSSBUILD_ARCH = 386 amd64
+OSARCH_COMBOS   = $(foreach os,$(CROSSBUILD_OS),$(addprefix $(os)_,$(CROSSBUILD_ARCH)))
 
 default: build
 
@@ -18,4 +22,24 @@ build:
 	@echo ">> building binaries"
 	@CGO_ENABLED=0 go build -o terraform-provider-sops
 
-.PHONY: all style vet test build
+crossbuild: $(GOPATH)/bin/gox
+		@echo ">> cross-building"
+		@gox -arch="$(CROSSBUILD_ARCH)" -os="$(CROSSBUILD_OS)" -output="binaries/{{.OS}}_{{.Arch}}/terraform-provider-sops_v$(VERSION)"
+
+$(GOPATH)/bin/gox:
+		# Need to disable modules for this to not pollute go.mod
+		@GO111MODULE=off go get -u github.com/mitchellh/gox
+
+release: crossbuild bin/github-release
+	@echo ">> uploading release ${VERSION}"
+	@mkdir -p releases
+	@set -e; for OSARCH in $(OSARCH_COMBOS); do \
+		zip -j releases/terraform-provider-sops_v$(VERSION)_$$OSARCH.zip binaries/$$OSARCH/terraform-provider-sops_* > /dev/null; \
+		./bin/github-release upload -t ${VERSION} -n terraform-provider-sops_v$(VERSION)_$$OSARCH.zip -f releases/terraform-provider-sops_v$(VERSION)_$$OSARCH.zip; \
+	done
+
+bin/github-release:
+	@mkdir -p bin
+	@curl -sL 'https://github.com/aktau/github-release/releases/download/v0.6.2/linux-amd64-github-release.tar.bz2' | tar xjf - --strip-components 3 -C bin
+
+.PHONY: all style vet test build crossbuild release

--- a/README.md
+++ b/README.md
@@ -46,11 +46,9 @@ output "do-something" {
 
 ## Install
 
-``` shell
-go get github.com/carlpett/terraform-provider-sops
-mkdir -p ~/.terraform.d/plugins
-ln -s $GOPATH/bin/terraform-provider-sops $HOME/.terraform.d/plugins/terraform-provider-sops
-```
+Download the latest [release](https://github.com/carlpett/terraform-provider-sops/releases) for your environment and unpack it to the user plugin directory. The user plugins directory is in one of the following locations, depending on the host operating system:
+* Windows `%APPDATA%\terraform.d\plugins`
+* All other systems `~/.terraform.d/plugins`
 
 ## Development
 Building and testing is most easily performed with `make build` and `make test` respectively.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
-FROM hashicorp/terraform:light
+FROM hashicorp/terraform:0.12.0
 ARG SOPS_PLUGIN_VERSION
 ENV SOPS_PLUGIN_VERSION=${SOPS_PLUGIN_VERSION}
-RUN curl -sLo /bin/terraform-provider-sops_${SOPS_PLUGIN_VERSION} https://github.com/carlpett/terraform-provider-sops/releases/download/${SOPS_PLUGIN_VERSION}/terraform-provider-sops_${SOPS_PLUGIN_VERSION}-linux-amd64 && \
+RUN wget https://github.com/carlpett/terraform-provider-sops/releases/download/${SOPS_PLUGIN_VERSION}/terraform-provider-sops_${SOPS_PLUGIN_VERSION}_linux_amd64.zip && \
+	unzip terraform-provider-sops_${SOPS_PLUGIN_VERSION}_linux_amd64.zip && \
+	mv terraform-provider-sops_${SOPS_PLUGIN_VERSION} /bin/terraform-provider-sops_${SOPS_PLUGIN_VERSION} && \
 	chmod +x /bin/terraform-provider-sops_${SOPS_PLUGIN_VERSION}


### PR DESCRIPTION
Fixes #18.

This PR sets up release builds for Windows, Linux and MacOS, with amd64 and 386 archs. Also updates the installation instructions to not suggest building from master, but downloading a release instead.