### PR TITLE
Add notice about plaintexts in Terraform state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Terraform plugin for using files encrypted with [Mozilla sops](https://github.com/mozilla/sops).
 
+**NOTE:** To prevent plaintext secrets from being written to disk, you *must* set up a secure remote state backend. See the [official docs](https://www.terraform.io/docs/state/sensitive-data.html) on _Sensitive Data in State_ for more information.
+
 ## Example
 
 Encrypt a file using Sops: `sops demo-secret.enc.json`


### PR DESCRIPTION
Per issue #33, this adds a notice to README.md about setting up a secure remote state backend when using this provider to prevent the leaking of plaintext secrets to disk.