### PR TITLE
Terraform registry

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,47 +1,53 @@
 export CGO_ENABLED = 0
 VERSION = $(shell git describe --tags --match='v*' --always)
+RELEASE = $(patsubst v%,%,$(VERSION))# Remove leading v to comply with Terraform Registry conventions
 
 CROSSBUILD_OS   = linux windows darwin
 CROSSBUILD_ARCH = 386 amd64
-OSARCH_COMBOS   = $(foreach os,$(CROSSBUILD_OS),$(addprefix $(os)_,$(CROSSBUILD_ARCH)))
+SKIP_OSARCH     = darwin_386
+OSARCH_COMBOS   = $(filter-out $(SKIP_OSARCH),$(foreach os,$(CROSSBUILD_OS),$(addprefix $(os)_,$(CROSSBUILD_ARCH))))
 
 default: build
 
 style:
 	@echo ">> checking code style"
-	@! gofmt -d $(shell find . -path ./vendor -prune -o -name '*.go' -print) | grep '^'
+	! gofmt -d $(shell find . -path ./vendor -prune -o -name '*.go' -print) | grep '^'
 
 vet:
 	@echo ">> vetting code"
-	@go vet ./...
+	go vet ./...
 
 test:
 	@echo ">> testing code"
-	@go test -v ./...
+	go test -v ./...
 
 build:
 	@echo ">> building binaries"
-	@go build -o terraform-provider-sops
+	go build -o terraform-provider-sops
 
 crossbuild: $(GOPATH)/bin/gox
 	@echo ">> cross-building"
-	@gox -arch="$(CROSSBUILD_ARCH)" -os="$(CROSSBUILD_OS)" -output="binaries/{{.OS}}_{{.Arch}}/terraform-provider-sops_$(VERSION)"
+	gox -arch="$(CROSSBUILD_ARCH)" -os="$(CROSSBUILD_OS)" -osarch="$(addprefix !,$(subst _,/,$(SKIP_OSARCH)))" \
+		-output="binaries/$(RELEASE)/{{.OS}}_{{.Arch}}/terraform-provider-sops_$(RELEASE)"
 
 $(GOPATH)/bin/gox:
 	# Need to disable modules for this to not pollute go.mod
 	@GO111MODULE=off go get -u github.com/mitchellh/gox
 
 release: crossbuild bin/hub
-	@echo ">> uploading release ${VERSION}"
-	@mkdir -p releases
-	@set -e; for OSARCH in $(OSARCH_COMBOS); do \
-		zip -j releases/terraform-provider-sops_$(VERSION)_$$OSARCH.zip binaries/$$OSARCH/terraform-provider-sops_* > /dev/null; \
-		./bin/hub release edit -a "releases/terraform-provider-sops_$(VERSION)_$$OSARCH.zip#terraform-provider-sops_$(VERSION)_$$OSARCH.zip" ${VERSION}; \
+	@echo ">> uploading release $(VERSION)"
+	mkdir -p releases
+	set -e; for OSARCH in $(OSARCH_COMBOS); do \
+		zip -j releases/terraform-provider-sops_$(RELEASE)_$$OSARCH.zip binaries/$(RELEASE)/$$OSARCH/terraform-provider-sops_* > /dev/null; \
+		./bin/hub release edit -m "" -a "releases/terraform-provider-sops_$(RELEASE)_$$OSARCH.zip#terraform-provider-sops_$(RELEASE)_$$OSARCH.zip" $(VERSION); \
 	done
+	@echo ">>> generating sha256sums:"
+	cd releases; sha256sum *.zip | tee terraform-provider-sops_$(RELEASE)_SHA256SUMS
+	./bin/hub release edit -m "" -a "releases/terraform-provider-sops_$(RELEASE)_SHA256SUMS#terraform-provider-sops_$(RELEASE)_SHA256SUMS" $(VERSION)
 
 bin/hub:
 	@mkdir -p bin
-	@curl -sL 'https://github.com/github/hub/releases/download/v2.14.1/hub-linux-amd64-2.14.1.tgz' | \
+	curl -sL 'https://github.com/github/hub/releases/download/v2.14.1/hub-linux-amd64-2.14.1.tgz' | \
 		tar -xzf - --strip-components 2 -C bin --wildcards '*/bin/hub'
 
 .PHONY: all style vet test build crossbuild release

--- a/docs/data-sources/external.md
+++ b/docs/data-sources/external.md
@@ -1,0 +1,32 @@
+# sops_external Data Source
+
+Read data from a sops-encrypted string. Useful if the data does not reside on disk locally (otherwise use `sops_file`).
+
+## Example Usage
+
+```hcl
+provider "sops" {}
+
+data "http" "remote_sops_data" {
+  url = "https://sops.example/my-data"
+}
+
+data "sops_external" "demo-secret" {
+  source     = data.http.remote_sops_data.body
+  input_type = "yaml"
+}
+
+output "root-value-hello" {
+  value = data.sops_external.demo-secret.data.hello
+}
+```
+
+## Argument Reference
+
+* `source` - (Required) A string with sops-encrypted data
+* `input_type` - (Required) `yaml`, `json` or `raw`, depending on the structure of the un-encrypted data.
+
+## Attribute Reference
+
+* `data` - The unmarshalled data as a dictionary. Use dot-separated keys to access nested data.
+* `raw` - The entire unencrypted file as a string.

--- a/docs/data-sources/file.md
+++ b/docs/data-sources/file.md
@@ -1,0 +1,38 @@
+# sops_file Data Source
+
+Read data from a sops-encrypted file on disk.
+
+## Example Usage
+
+```hcl
+provider "sops" {}
+
+data "sops_file" "demo-secret" {
+  source_file = "demo-secret.enc.json"
+}
+
+output "root-value-password" {
+  # Access the password variable from the map
+  value = data.sops_file.demo-secret.data["password"]
+}
+
+output "mapped-nested-value" {
+  # Access the password variable that is under db via the terraform map of data
+  value = data.sops_file.demo-secret.data["db.password"]
+}
+
+output "nested-json-value" {
+  # Access the password variable that is under db via the terraform object
+  value = jsondecode(data.sops_file.demo-secret.raw).db.password
+}
+```
+
+## Argument Reference
+
+* `source_file` - (Required) Path to the encrypted file
+* `input_type` - (Optional) The provider will use the file extension to determine how to unmarshal the data. If your file does not have the usual extension, set this argument to `yaml` or `json` accordingly, or `raw` if the encrypted data is encoded differently.
+
+## Attribute Reference
+
+* `data` - The unmarshalled data as a dictionary. Use dot-separated keys to access nested data.
+* `raw` - The entire unencrypted file as a string.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# sops Provider
+
+A Terraform plugin for using files encrypted with [Mozilla sops](https://github.com/mozilla/sops).
+
+!> To prevent plaintext secrets from being written to disk, you *must* use a secure remote state backend. See the [official docs](https://www.terraform.io/docs/state/sensitive-data.html) on _Sensitive Data in State_ for more information.
+
+## Example Usage
+
+```hcl
+provider "sops" {}
+
+data "sops_file" "demo-secret" {
+  source_file = "demo-secret.enc.json"
+}
+
+output "db-password" {
+  # Access the password variable that is under db via the terraform map of data
+  value = data.sops_file.demo-secret.data["db.password"]
+}
+```


### PR DESCRIPTION
This PR makes the repo compliant with the things needed to work with the Terraform Registry, which will allow automatic downloads from TF 0.13 and later:
- Documentation that will feature on the [Registry page](https://registry.terraform.io/providers/carlpett/sops)
- Release script changes to generate the right file names (there should not be a leading `v` in the version in the zip archives, but there should be one in the binary name), and uploading sha256 sums.