### PR TITLE
Workaround for sops #555

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/carlpett/terraform-provider-sops
+module github.com/ahawkins/terraform-provider-sops
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/carlpett/terraform-provider-sops/sops"
+	"github.com/ahawkins/terraform-provider-sops/sops"
 
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
 )


### PR DESCRIPTION
REF: https://github.com/mozilla/sops/issues/555

I need something like this because we apply terraform in our CD pipelines. Humans need to assume a role on their machine to use sops. CI/CD doesn't because those machines have access via AWS Instance Profiles.

I don't know a better solution to this problem. It would be nice to rely on structured data manipulation. Unfortunately the `content` must be munged before passing to the `sops` library. If the `role` config is present then sops will try to assume that role. 

I'm not sure if this PR should be merged. I'm opening for feedback in search of a better solution.