### PR TITLE
Mark data+raw resource attributes as sensitive.

### DIFF
--- a/sops/data_sops_external.go
+++ b/sops/data_sops_external.go
@@ -26,10 +26,12 @@ func dataSourceExternal() *schema.Resource {
 			"data": &schema.Schema{
 				Type:     schema.TypeMap,
 				Computed: true,
+				Sensitive: true,
 			},
 			"raw": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
+				Sensitive: true,
 			},
 		},
 	}

--- a/sops/data_sops_file.go
+++ b/sops/data_sops_file.go
@@ -27,10 +27,12 @@ func dataSourceFile() *schema.Resource {
 			"data": &schema.Schema{
 				Type:     schema.TypeMap,
 				Computed: true,
+				Sensitive: true,
 			},
 			"raw": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
+				Sensitive: true,
 			},
 		},
 	}


### PR DESCRIPTION
This ensures that when data from this plugin is passed around, it's hidden from display no matter what.

https://www.terraform.io/docs/configuration/expressions/references.html#sensitive-resource-attributes