### PR TITLE
Add support for env and ini files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,5 +29,6 @@ require (
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a // indirect
 	google.golang.org/grpc v1.25.1 // indirect
+	gopkg.in/ini.v1 v1.62.0
 	gopkg.in/yaml.v2 v2.2.5
 )

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,7 @@ github.com/aws/aws-sdk-go v1.25.3 h1:uM16hIw9BotjZKMZlX05SN2EFtaWfi/NonPKIARiBLQ
 github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.31 h1:14mdh3HsTgRekePPkYcCbAaEXJknc3mN7f4XfsiMMDA=
 github.com/aws/aws-sdk-go v1.25.31/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.33.18 h1:Ccy1SV2SsgJU3rfrD+SOhQ0jvuzfrFuja/oKI86ruPw=
 github.com/aws/aws-sdk-go v1.33.18/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
@@ -266,6 +267,7 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -351,6 +353,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -418,6 +421,7 @@ go.mozilla.org/gopgagent v0.0.0-20170926210634-4d7ea76ff71a h1:N7VD+PwpJME2ZfQT8
 go.mozilla.org/gopgagent v0.0.0-20170926210634-4d7ea76ff71a/go.mod h1:YDKUvO0b//78PaaEro6CAPH6NqohCmL2Cwju5XI2HoE=
 go.mozilla.org/sops/v3 v3.6.0 h1:V+RjhX96enZY9a5iVP/r60lLABq8/8Pv2Fybh10Np3g=
 go.mozilla.org/sops/v3 v3.6.0/go.mod h1:X8YOCEZzMFL0p28vkqtn3gW2eFt+dDUt7HwKXGvcXvA=
+go.mozilla.org/sops/v3 v3.6.1 h1:SQXX2hXcZHBw4ZIPpvFbEns6hA7f2rE6kbN6E0heEkM=
 go.mozilla.org/sops/v3 v3.6.1/go.mod h1:3KLncZfyE0cG/28CriTo0JJMARroeKToDIISBgN93xw=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
@@ -486,6 +490,7 @@ golang.org/x/net v0.0.0-20191009170851-d66e71096ffb/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191109021931-daa7c04131f5 h1:bHNaocaoJxYBo5cw41UyTMLjYlb8wPY7+WFrnklbHOM=
 golang.org/x/net v0.0.0-20191109021931-daa7c04131f5/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -613,6 +618,8 @@ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/ini.v1 v1.44.0 h1:YRJzTUp0kSYWUVFF5XAbDFfyiqwsl0Vb9R8TVP5eRi0=
 gopkg.in/ini.v1 v1.44.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/ini.v1 v1.62.0 h1:duBzk771uxoUuOlyRLkHsygud9+5lrlGjdFBb4mSKDU=
+gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/sops/data_sops_file.go
+++ b/sops/data_sops_file.go
@@ -54,6 +54,10 @@ func dataSourceFileRead(d *schema.ResourceData, meta interface{}) error {
 			format = "json"
 		case ".yaml", ".yml":
 			format = "yaml"
+		case ".env":
+			format = "dotenv"
+		case ".ini":
+			format = "ini"
 		default:
 			return fmt.Errorf("Don't know how to decode file with extension %s, set input_type to json, yaml or raw as appropriate", ext)
 		}

--- a/sops/internal/dotenv/dotenv.go
+++ b/sops/internal/dotenv/dotenv.go
@@ -1,0 +1,29 @@
+package dotenv
+
+import (
+	"fmt"
+	"bytes"
+	"strings"
+)
+
+func Unmarshal(in []byte, out *map[string]interface{}) error {
+	if *out == nil {
+		*out = make(map[string]interface{})
+	}
+	for _, line := range bytes.Split(in, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		if line[0] == '#' {
+			continue
+		} else {
+			pos := bytes.Index(line, []byte("="))
+			if pos == -1 {
+				return fmt.Errorf("invalid dotenv input line: %s", line)
+			}
+			(*out)[string(line[:pos])] = strings.Replace(string(line[pos+1:]), "\\n", "\n", -1)
+		}
+	}
+
+	return nil
+}

--- a/sops/internal/dotenv/dotenv_test.go
+++ b/sops/internal/dotenv/dotenv_test.go
@@ -1,0 +1,22 @@
+package dotenv
+
+import (
+	"testing"
+	"reflect"
+)
+
+func TestUnmarshal(t *testing.T) {
+	input := []byte(`# Comment!
+password=P@ssw0rd`)
+	expectedOutput := map[string]interface{}{
+		"password":"P@ssw0rd",
+	}
+	var data map[string]interface{}
+	err := Unmarshal(input, &data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expectedOutput, data) {
+		t.Errorf("Unexpected output, expected %v, got %v", expectedOutput, data)
+	}
+}

--- a/sops/internal/ini/ini.go
+++ b/sops/internal/ini/ini.go
@@ -1,0 +1,34 @@
+package ini
+
+import (
+	"gopkg.in/ini.v1"
+)
+
+func Unmarshal(in []byte, out *map[string]interface{}) error {
+	f, err := ini.Load(in)
+	if err != nil {
+		return err
+	}
+
+	if *out == nil {
+		*out = make(map[string]interface{})
+	}
+
+	for _, s := range f.Sections() {
+		var m map[string]interface{}
+		// The root section key-value pairs should go directly on the root of the
+		// map, not under a default subkey
+		if s.Name() == ini.DefaultSection {
+			m = *out
+		} else {
+			m = make(map[string]interface{})
+			(*out)[s.Name()] = m
+		}
+
+		for _, k := range s.Keys() {
+			m[k.Name()] = k.Value()
+		}
+	}
+
+	return nil
+}

--- a/sops/internal/ini/ini_test.go
+++ b/sops/internal/ini/ini_test.go
@@ -1,0 +1,27 @@
+package ini
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUnmarshal(t *testing.T) {
+	input := []byte(`; Comment!
+rootKey = foo
+[Some section]
+example_key = example_value`)
+	expectedOutput := map[string]interface{}{
+		"rootKey": "foo",
+		"Some section": map[string]interface{}{
+			"example_key": "example_value",
+		},
+	}
+	var data map[string]interface{}
+	err := Unmarshal(input, &data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expectedOutput, data) {
+		t.Errorf("Unexpected output, expected %v, got %v", expectedOutput, data)
+	}
+}

--- a/sops/read_data.go
+++ b/sops/read_data.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"go.mozilla.org/sops/v3/decrypt"
 	"gopkg.in/yaml.v2"
+
+	"github.com/carlpett/terraform-provider-sops/sops/internal/dotenv"
+	"github.com/carlpett/terraform-provider-sops/sops/internal/ini"
 )
 
 // readData consolidates the logic of extracting the from the various input methods and setting it on the ResourceData
@@ -28,6 +31,10 @@ func readData(content []byte, format string, d *schema.ResourceData) error {
 		err = json.Unmarshal(cleartext, &data)
 	case "yaml":
 		err = yaml.Unmarshal(cleartext, &data)
+	case "dotenv":
+		err = dotenv.Unmarshal(cleartext, &data)
+	case "ini":
+		err = ini.Unmarshal(cleartext, &data)
 	}
 	if err != nil {
 		return err

--- a/sops/validate.go
+++ b/sops/validate.go
@@ -7,11 +7,15 @@ func validateInputType(inputType string) error {
 	switch inputType {
 	case "json":
 		return nil
-	case "yaml", "yml":
+	case "yaml":
+		return nil
+	case "dotenv":
+		return nil
+	case "ini":
 		return nil
 	case "raw":
 		return nil
 	default:
-		return fmt.Errorf("Don't know how to decode file with input type %s, set input_type to json, yaml or raw as appropriate", inputType)
+		return fmt.Errorf("Don't know how to decode file with input type %s, set input_type to json, yaml, ini, dotenv or raw as appropriate", inputType)
 	}
 }


### PR DESCRIPTION
Sops has added support for .ini and .env files, which we then need to support as well. This PR adds unmarshalling and mapping support for those file types.
Fixes #59 