### PR TITLE
Impove SOPS error messages

### DIFF
--- a/sops/read_data.go
+++ b/sops/read_data.go
@@ -2,8 +2,10 @@ package sops
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"go.mozilla.org/sops/v3"
 	"go.mozilla.org/sops/v3/decrypt"
 	"gopkg.in/yaml.v2"
 
@@ -14,6 +16,9 @@ import (
 // readData consolidates the logic of extracting the from the various input methods and setting it on the ResourceData
 func readData(content []byte, format string, d *schema.ResourceData) error {
 	cleartext, err := decrypt.Data(content, format)
+	if userErr, ok := err.(sops.UserError); ok {
+		err = fmt.Errorf(userErr.UserError())
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This improvement is similar to this one https://github.com/isindir/sops-secrets-operator/issues/23 and it can help debugging issues referred to in: https://github.com/carlpett/terraform-provider-sops/issues/81 and https://github.com/carlpett/terraform-provider-sops/issues/74

At the moment, error messages look like this:

```
│ Error: Error getting data key: 0 successful groups required, got 0
│
│   with data.sops_file.xxx,
│   on main.tf line 114, in data "sops_file" "xxx":
│  114: data "sops_file" "xxx" {
```

Afterwards the error message can look like this (of course it depends on
the error):

```
| Error: Failed to get the data key required to decrypt the SOPS file.
│
│ Group 0: FAILED
│   XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX: FAILED
│     - | could not decrypt data key with PGP key:
│       | golang.org/x/crypto/openpgp error: Could not load secring:
│       | open /Users/<user>/.gnupg/secring.gpg: no such file or
│       | directory; GPG binary error: exit status 2
│
│ Recovery failed because no master key was able to decrypt the file. In
│ order for SOPS to recover the file, at least one key has to be successful,
│ but none were.
│
│   with data.sops_file.xxx,
│   on main.tf line 173, in data "sops_file" "xxx":
│  173: data "sops_file" "xxx" {
```

Kudos to @kdomanski for pointing me to the GitHub issue containing the improvement 👍 