### PR TITLE
Avoid running tests twice on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Tests
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 env:
   GO_VERSION: '1.21'


### PR DESCRIPTION
Tests are triggered both on PRs as well as branch pushes, leading PRs to get double test runs. Only trigger the branch push on merge to master.